### PR TITLE
Upgrades of Portainer, Traefik and Docker-Compose

### DIFF
--- a/portainer/docker-compose.yml
+++ b/portainer/docker-compose.yml
@@ -1,8 +1,9 @@
-version: '3'
+version: '3.3'
 
 services:
   portainer:
-    image: portainer/portainer:1.23.2
+#    image: portainer/portainer:1.23.2
+    image: portainer/portainer-ce
     container_name: portainer
     restart: unless-stopped
     security_opt:

--- a/traefik/docker-compose.yml
+++ b/traefik/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.3"
 
 services:
   traefik:
-    image: traefik:2.2.1
+    image: traefik:latest
     container_name: traefik
     hostname: traefik
     restart: unless-stopped

--- a/watchtower/docker-compose.yml
+++ b/watchtower/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: '3.3'
 
 services:
   watchtower:


### PR DESCRIPTION
Big change was upgrade from Portainer 1.x to 2.x.  Other bits got minor version updates.  All appear to be working on DGDockerX.